### PR TITLE
Update Warp10 container to version 3.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val testContainersScalaVersion = "0.41.5"
-lazy val testContainersWarp10Version = "1.0.8"
+lazy val testContainersWarp10Version = "2.0.1"
 lazy val akkaVersion = "2.8.8"
 
 ThisBuild / semanticdbVersion := "4.12.1"
@@ -9,7 +9,7 @@ credentials += Credentials("GnuPG Key ID", "gpg", "B11C53C05D413713BDD3660FA7B8F
 lazy val root = (project in file(".")).settings(
   organization := "com.clever-cloud",
   scalaVersion := "2.13.15",
-  version := "2.1.2",
+  version := "2.1.3",
   crossScalaVersions := Seq(scalaVersion.value, "3.6.2"),
   name := "testcontainers-scala-warp10",
   licenses := List("MIT" -> new URI("https://mit-license.org/").toURL()),

--- a/src/main/scala/com.clevercloud.testcontainers.scala/Warp10Container.scala
+++ b/src/main/scala/com.clevercloud.testcontainers.scala/Warp10Container.scala
@@ -40,7 +40,7 @@ case class Warp10Container(
 }
 
 object Warp10Container {
-  val defaultTag = "2.7.5"
+  val defaultTag = "3.4.1-ubuntu-ci"
 
   case class Def(
     tag: String,

--- a/src/test/scala/com/clevercloud/testcontainers/scala/Warp10ContainerSpecs.scala
+++ b/src/test/scala/com/clevercloud/testcontainers/scala/Warp10ContainerSpecs.scala
@@ -29,7 +29,7 @@ class Warp10ContainerSpecs extends AnyWordSpec
   private val Warp10FetchedHeader = "X-Warp10-Fetched"
   private val Warp10GTS = "1// test{} 42"
   private val Warp10UpdateAPI = "/api/v0/update"
-  private val Warp10Version = "2.7.5"
+  private val Warp10Version = "3.4.1-ubuntu-ci"
 
   val container: Warp10Container = Warp10Container(Warp10Version)
 


### PR DESCRIPTION
Upgraded the default Warp10 container tag and test dependencies to their latest versions.

This MR is dependant on https://github.com/CleverCloud/testcontainers-warp10/pull/6 is merged