### PR TITLE
Remove redundant `sonatypeCredentialHost` configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,6 @@ jobs:
             "s01.oss.sonatype.org",
             "${{ secrets.OSSRH_USERNAME }}",
             "${{ secrets.OSSRH_TOKEN }}")
-          sonatypeCredentialHost := "s01.oss.sonatype.org"
           EOF
 
       - name: publish sonatypeRelease


### PR DESCRIPTION
The `sonatypeCredentialHost` line was unnecessary