### PR TITLE
Switch release workflow trigger to push for tags and branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,15 +1,9 @@
 name: release
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "The release version"
-        required: true
-      branch:
-        description: "The branch to release from"
-        required: true
-        default: "master"
+  push:
+    branches: ['**']
+    tags: [v*]
 
 jobs:
   release-scala-2-13:


### PR DESCRIPTION
Replaced the manual workflow_dispatch trigger with an automated push trigger for all branches and version tags matching "v*".